### PR TITLE
Update navigation postmeeting

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -10,10 +10,6 @@
   text-align: center;
 }
 
-#navHamContainer {
-  margin: 2vw;
-}
-
 div.logoDiv {
   height: 19vh;
   width: 100%;

--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -10,7 +10,7 @@ header {
 #navGrid {
    width: 30vw;
    height: 100vh;
-   padding-top: 10vh;
+   padding-top: 75px;
    position: absolute;
    background-color: var(--greyBgC);
    -webkit-transition: 0.4s;
@@ -195,6 +195,12 @@ header {
    }
    to {
       margin-left: -100%;
+   }
+}
+
+@media (min-width: 1799px) {
+   #navGrid {
+      width: 20vw;
    }
 }
 

--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -10,6 +10,7 @@ header {
 #navGrid {
    width: 30vw;
    height: 100vh;
+   padding-top: 10vh;
    position: absolute;
    background-color: var(--greyBgC);
    -webkit-transition: 0.4s;
@@ -78,6 +79,7 @@ header {
    cursor: pointer;
    z-index: 98;
    margin: 2vw;
+   position: absolute;
 }
 
 .navBar1, .navBar2, .navBar3 {

--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -27,6 +27,10 @@ header {
    font-weight: 700;
 }
 
+.currentSubPage {
+   text-decoration: underline !important;
+}
+
 #navGrid > a {
    text-decoration: none;
    color: var(--whiteFontC);
@@ -73,6 +77,7 @@ header {
    width: 35px;
    cursor: pointer;
    z-index: 98;
+   margin: 2vw;
 }
 
 .navBar1, .navBar2, .navBar3 {
@@ -194,7 +199,6 @@ header {
 @media (max-width: 900px) {
    #navGrid {
       width: 50vw;
-      left: -200vw;
    }
 }
 

--- a/public/js/navigation.js
+++ b/public/js/navigation.js
@@ -9,38 +9,42 @@ const navEvent = document.querySelector('.navEvents');
 const navTheGame = document.querySelector('.navGame');
 const navRegister = document.querySelector('.navRegister');
 
+let navShowingAbout = false;
+let navShowingEvents = false;
+let navShowingGame = false;
+
 switch (navPageName) {
   case 'about-project':
     navAbout.classList.toggle('currentPage');
-    document.querySelector('.navAboutProject').classList.toggle('currentPage');
+    document.querySelector('.navAboutProject').classList.toggle('currentSubPage');
     break;
   case 'about-team':
     navAbout.classList.toggle('currentPage');
-    document.querySelector('.navAboutTeam').classList.toggle('currentPage');
+    document.querySelector('.navAboutTeam').classList.toggle('currentSubPage');
     break;
   case 'beta-testing':
     navEvent.classList.toggle('currentPage');
-    document.querySelector('.navBetaTesting').classList.toggle('currentPage');
+    document.querySelector('.navBetaTesting').classList.toggle('currentSubPage');
     break;
   case 'release':
     navEvent.classList.toggle('currentPage');
-    document.querySelector('.navReleaseDay').classList.toggle('currentPage');
+    document.querySelector('.navReleaseDay').classList.toggle('currentSubPage');
     break;
   case 'rules':
     navTheGame.classList.toggle('currentPage');
-    document.querySelector('.navRules').classList.toggle('currentPage');
+    document.querySelector('.navRules').classList.toggle('currentSubPage');
     break;
   case 'crews':
     navTheGame.classList.toggle('currentPage');
-    document.querySelector('.navCrews').classList.toggle('currentPage');
+    document.querySelector('.navCrews').classList.toggle('currentSubPage');
     break;
   case 'planets':
     navTheGame.classList.toggle('currentPage');
-    document.querySelector('.navPlanets').classList.toggle('currentPage');
+    document.querySelector('.navPlanets').classList.toggle('currentSubPage');
     break;
   case 'actions':
     navTheGame.classList.toggle('currentPage');
-    document.querySelector('.navActions').classList.toggle('currentPage');
+    document.querySelector('.navActions').classList.toggle('currentSubPage');
     break;
   case 'register':
     navRegister.classList.toggle('currentPage');
@@ -61,7 +65,24 @@ navHam.addEventListener('click', (event) => {
 });
 
 function displayNavDiv(divClass, showing) {
-  const navDiv = document.querySelector(divClass);
+  const navDiv = document.querySelector(`.${divClass}`);
+  const selectedMenu = document.querySelector('.menuDropVisable');
+
+  if (selectedMenu) {
+    const anySelected = Array.from(selectedMenu.className.split(' '));
+    // if (anySelected.includes('gameDiv'))
+    if (!anySelected.includes(divClass)) {
+      if (anySelected.includes('gameDiv')) {
+        selectedMenu.classList.toggle('menuDropDownShowingTheGame');
+        navShowingGame = false;
+      } else {
+        selectedMenu.classList.toggle('menuDropDownShowing');
+        if (anySelected.includes('aboutDiv')) navShowingAbout = false;
+        if (anySelected.includes('eventDiv')) navShowingEvents = false;
+      }
+      selectedMenu.classList.toggle('menuDropVisable');
+    }
+  }
 
   if (showing) {
     setTimeout(() => {
@@ -71,28 +92,25 @@ function displayNavDiv(divClass, showing) {
     navDiv.classList.toggle('menuDropVisable');
   }
 
-  if (divClass === '.gameDiv') navDiv.classList.toggle('menuDropDownShowingTheGame');
+  if (divClass === 'gameDiv') navDiv.classList.toggle('menuDropDownShowingTheGame');
   else navDiv.classList.toggle('menuDropDownShowing');
 }
-let navShowingAbout = false;
-let navShowingEvents = false;
-let navShowingGame = false;
 
 navAbout.addEventListener('click', (event) => {
   event.stopPropagation();
-  displayNavDiv('.aboutDiv', navShowingAbout);
+  displayNavDiv('aboutDiv', navShowingAbout);
   navShowingAbout = !navShowingAbout;
 });
 
 navEvent.addEventListener('click', (event) => {
   event.stopPropagation();
-  displayNavDiv('.eventDiv', navShowingEvents);
+  displayNavDiv('eventDiv', navShowingEvents);
   navShowingEvents = !navShowingEvents;
 });
 
 navTheGame.addEventListener('click', (event) => {
   event.stopPropagation();
-  displayNavDiv('.gameDiv', navShowingGame);
+  displayNavDiv('gameDiv', navShowingGame);
   navShowingGame = !navShowingGame;
 });
 

--- a/public/js/navigation.js
+++ b/public/js/navigation.js
@@ -70,7 +70,6 @@ function displayNavDiv(divClass, showing) {
 
   if (selectedMenu) {
     const anySelected = Array.from(selectedMenu.className.split(' '));
-    // if (anySelected.includes('gameDiv'))
     if (!anySelected.includes(divClass)) {
       if (anySelected.includes('gameDiv')) {
         selectedMenu.classList.toggle('menuDropDownShowingTheGame');

--- a/public/js/navigation.js
+++ b/public/js/navigation.js
@@ -79,7 +79,9 @@ function displayNavDiv(divClass, showing) {
         if (anySelected.includes('aboutDiv')) navShowingAbout = false;
         if (anySelected.includes('eventDiv')) navShowingEvents = false;
       }
-      selectedMenu.classList.toggle('menuDropVisable');
+      setTimeout(() => {
+        selectedMenu.classList.toggle('menuDropVisable');
+      }, animationDurations);
     }
   }
 


### PR DESCRIPTION
Updated the navigation with some functionality and css according to the dev-meeting (Tuesday 20/4).
Including: Menu reach all the way to the top, opened menu-links closes when the user press another, underline is added to sub-link (I'm aware that you want us to avoid !important, but in this case there would have to be a quite a few changes to get that right, but I'll look into it), and all pages have links to the navigation.js, and the navHam is placed at the same spot on all pages that are correctly linked and without changes in their css.
<img width="427" alt="Skärmavbild 2021-04-20 kl  17 59 19" src="https://user-images.githubusercontent.com/74403806/115428397-a661e580-a202-11eb-8921-8e1135e0b6c4.png">
<img width="433" alt="Skärmavbild 2021-04-20 kl  17 59 29" src="https://user-images.githubusercontent.com/74403806/115428404-a7931280-a202-11eb-9868-d0f8203156c8.png">

